### PR TITLE
Supported IPFS version bump

### DIFF
--- a/ipfshttpclient4ipwb/client/__init__.py
+++ b/ipfshttpclient4ipwb/client/__init__.py
@@ -15,7 +15,7 @@ DEFAULT_BASE = str(os.environ.get("PY_IPFS_HTTP_CLIENT_DEFAULT_BASE", 'api/v0'))
 
 VERSION_MINIMUM   = "0.4.21"
 VERSION_BLACKLIST = []
-VERSION_MAXIMUM   = "0.6.0"
+VERSION_MAXIMUM   = "0.7.0"
 
 from . import bitswap
 from . import block


### PR DESCRIPTION
Making this change to see if https://github.com/oduwsdl/ipwb/pull/670 will pass after a new version of this client is released to PyPI.